### PR TITLE
Fix a few type hints

### DIFF
--- a/examples/example01/prog.py
+++ b/examples/example01/prog.py
@@ -1,5 +1,8 @@
 import random
-def my_program(x: int, y: int, z: int) -> int:
+from typing import Tuple
+
+
+def my_program(x: int, y: int, z: int) -> Tuple[int, str, bool]:
     b = x + y
     c = x - y
     res = ""

--- a/src/pacfix/invariant.py
+++ b/src/pacfix/invariant.py
@@ -197,14 +197,13 @@ class InvariantManager():
         self.invs.append(inv)
         return len(self.invs) - 1
     
-    def get_invariant_by_id(self, id: int) -> List[Invariant]:
+    def get_invariant_by_id(self, id: int) -> Optional[Invariant]:
         if id < 0 or id >= len(self.invs):
             return None
         return self.invs[id]
     
-    def add_invariant_to_lattice_recursive(self, parent: Lattice, inv: Lattice):
-        for c in parent.get_children():
-            pass
+    def add_invariant_to_lattice_recursive(self, parent: Set[Lattice], inv: Lattice):
+        pass
     
     def add_invariant_to_lattice(self, inv: Invariant) -> int:
         inv_id = self.add_invariant(inv)

--- a/src/pacfix/utils.py
+++ b/src/pacfix/utils.py
@@ -18,7 +18,7 @@ def parse_valuation(neg: List[str], pos: List[str]) -> Tuple[List[Dict[int, int]
     for valuation in neg:
         groups: List[Dict[int, int]] = list()
         in_group = False
-        val_map = dict()
+        val_map: Dict[int, int] = dict()
         for line in valuation.split("\n"):
             if line.startswith("#") or len(line) < 3:
                 continue
@@ -39,7 +39,7 @@ def parse_valuation(neg: List[str], pos: List[str]) -> Tuple[List[Dict[int, int]
             else:
                 neg_vals.append(val_map)
     for valuation in pos:
-        groups: List[Dict[int, int]] = list()
+        groups = list()
         in_group = False
         val_map = dict()
         for line in valuation.split("\n"):
@@ -58,12 +58,12 @@ def parse_valuation(neg: List[str], pos: List[str]) -> Tuple[List[Dict[int, int]
             pos_vals.append(val_map)
     return neg_vals, pos_vals
 
-def parse_valuations_uni(neg: List[str], pos: List[str]) -> List[Dict[int, int]]:
+def parse_valuations_uni(neg: List[str], pos: List[str]) -> Tuple[List[Dict[int, int]], List[Dict[int, int]]]:
     neg_vals = list()
     pos_vals = list()
     for valuation in neg:
         groups: List[Dict[int, int]] = list()
-        val_map = dict()
+        val_map: Dict[int, int] = dict()
         for line in valuation.split("\n"):
             if line.startswith("#") or len(line) < 3:
                 continue
@@ -84,7 +84,7 @@ def parse_valuations_uni(neg: List[str], pos: List[str]) -> List[Dict[int, int]]
             else:
                 neg_vals.append(val_map)
     for valuation in pos:
-        groups: List[Dict[int, int]] = list()
+        groups = list()
         in_group = False
         val_map = dict()
         for line in valuation.split("\n"):


### PR DESCRIPTION
This patch only includes trivial fixes.  Mypy still complains about the following:

* Lack of type hints for pysmt: this can either be ignored or a minimal stub for pysmt can be vendored
* Implicit None value of Invariant.{left,right}: the type-safe way to handle this statically would be to subclass the variable and constant invariant

It's also okay IMHO to ignore these issues and have type hints as extra documentations.